### PR TITLE
[FEAT] Question 도메인 도메인 클래스 및 레포지토리 생성, 조회 쿼리 구현

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -16,7 +16,7 @@ model BasicUser {
 
 model Hashtag {
   hashtag_id      BigInt            @id @default(autoincrement())
-  name            String            @db.VarChar(20)
+  name            String            @unique(map: "name") @db.VarChar(20)
   QuestionHashtag QuestionHashtag[]
 }
 
@@ -67,7 +67,7 @@ model QuestionHashtag {
 
   @@unique([question_id, hashtag_id], map: "question_id")
   @@unique([question_id, hashtag_id], map: "question_id_2")
-  @@index([hashtag_id], map: "FK_Hashtag_TO_QuestionHashtag_1")
+  @@unique([hashtag_id, question_id], map: "hashtag_id")
 }
 
 model QuestionImage {

--- a/server/src/modules/question/QuestionModule.ts
+++ b/server/src/modules/question/QuestionModule.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class QuestionModule {}

--- a/server/src/modules/question/QuestionModule.ts
+++ b/server/src/modules/question/QuestionModule.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/CommonModule';
+import { QuestionRepository } from './QuestionRepository';
 
-@Module({})
+@Module({
+  imports: [CommonModule],
+  providers: [QuestionRepository],
+})
 export class QuestionModule {}

--- a/server/src/modules/question/QuestionRepository.ts
+++ b/server/src/modules/question/QuestionRepository.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaInstance } from '../common/PrismaInstance';
+import Hashtag from './domain/Hashtag';
+import Option from './domain/Option';
+import Question from './domain/Question';
+import QuestionImage from './domain/QuestionImage';
+import QuestionType from './enum/QuestionType';
+
+@Injectable()
+export class QuestionRepository {
+  constructor(private readonly prisma: PrismaInstance) {}
+  async save(question: Question) {
+    if (question.questionId) {
+      return await this.updateQuestion(question);
+    }
+    return await this.createQuestion(question);
+  }
+
+  async createQuestion(question: Question) {
+    const newQuestion = await this.prisma.question.create({
+      data: {
+        question: question.question,
+        question_type: question.questionType,
+        user_id: question.userId,
+        answer: question.answer,
+        commentary: question.commentary,
+        created_at: question.createdAt,
+        updated_at: question.updatedAt,
+      },
+    });
+    question.setId(newQuestion.question_id);
+
+    if (question.images) {
+      question.images.forEach(async (image) => await this.createQuestionImage(image));
+    }
+
+    if (question.hashtags) {
+      question.hashtags.forEach(async (hashtag) => {
+        await this.createHashtag(hashtag);
+        await this.createQuestionHashtag(question.questionId, hashtag.hashtagId);
+      });
+    }
+
+    if (question.questionType === QuestionType.MULTIPLE && question.options) {
+      question.options.forEach(async (option) => await this.createOption(option));
+    }
+
+    return question;
+  }
+
+  async updateQuestion(question: Question) {
+    await this.prisma.question.update({
+      where: {
+        question_id: question.questionId,
+      },
+      data: {
+        question: question.question,
+        answer: question.answer,
+        commentary: question.commentary,
+        updated_at: question.updatedAt,
+      },
+    });
+    return question;
+  }
+
+  async createQuestionImage(questionImage: QuestionImage) {
+    const newImage = await this.prisma.questionImage.create({
+      data: {
+        path: questionImage.path,
+        question_id: questionImage.questionId,
+      },
+    });
+    questionImage.setId(newImage.question_id);
+    return questionImage;
+  }
+
+  async createHashtag(hashtag: Hashtag) {
+    const newHashtag = await this.prisma.hashtag.upsert({
+      where: {
+        name: hashtag.name,
+      },
+      create: {
+        name: hashtag.name,
+      },
+      update: {},
+    });
+    hashtag.setId(newHashtag.hashtag_id);
+    return hashtag;
+  }
+
+  async createQuestionHashtag(questionId: bigint, hashtagId: bigint) {
+    await this.prisma.questionHashtag.create({
+      data: {
+        question_id: questionId,
+        hashtag_id: hashtagId,
+      },
+    });
+  }
+
+  async createOption(option: Option) {
+    const newOption = this.prisma.option.create({
+      data: {
+        content: option.content,
+        question_id: option.questionId,
+      },
+    });
+    option.setId((await newOption).option_id);
+    return option;
+  }
+}

--- a/server/src/modules/question/domain/Hashtag.ts
+++ b/server/src/modules/question/domain/Hashtag.ts
@@ -1,0 +1,16 @@
+import { Hashtag as pHashtag } from '@prisma/client';
+
+class Hashtag {
+  public hashtagId: bigint;
+  public name: string;
+  constructor(hashtagId: bigint, name: string) {
+    this.hashtagId = hashtagId;
+    this.name = name;
+  }
+
+  static of(record: pHashtag) {
+    return new Hashtag(record.hashtag_id, record.name);
+  }
+}
+
+export default Hashtag;

--- a/server/src/modules/question/domain/Hashtag.ts
+++ b/server/src/modules/question/domain/Hashtag.ts
@@ -1,7 +1,7 @@
 import { Hashtag as pHashtag } from '@prisma/client';
 
 class Hashtag {
-  public hashtagId: bigint;
+  public hashtagId: bigint | undefined;
   public name: string;
   constructor(hashtagId: bigint, name: string) {
     this.hashtagId = hashtagId;
@@ -10,6 +10,10 @@ class Hashtag {
 
   static of(record: pHashtag) {
     return new Hashtag(record.hashtag_id, record.name);
+  }
+
+  setId(hashtagId: bigint) {
+    this.hashtagId = hashtagId;
   }
 }
 

--- a/server/src/modules/question/domain/Option.ts
+++ b/server/src/modules/question/domain/Option.ts
@@ -1,0 +1,18 @@
+import { Option as pOption } from '@prisma/client';
+
+class Option {
+  public optionId: bigint;
+  public content: string;
+  public questionId: bigint;
+  constructor(optionId: bigint, content: string, questionId: bigint) {
+    this.optionId = optionId;
+    this.content = content;
+    this.questionId = questionId;
+  }
+
+  static of(record: pOption) {
+    return new Option(record.option_id, record.content, record.question_id);
+  }
+}
+
+export default Option;

--- a/server/src/modules/question/domain/Option.ts
+++ b/server/src/modules/question/domain/Option.ts
@@ -1,7 +1,7 @@
 import { Option as pOption } from '@prisma/client';
 
 class Option {
-  public optionId: bigint;
+  public optionId: bigint | undefined;
   public content: string;
   public questionId: bigint;
   constructor(optionId: bigint, content: string, questionId: bigint) {
@@ -12,6 +12,10 @@ class Option {
 
   static of(record: pOption) {
     return new Option(record.option_id, record.content, record.question_id);
+  }
+
+  setId(optionId: bigint) {
+    this.optionId = optionId;
   }
 }
 

--- a/server/src/modules/question/domain/Question.ts
+++ b/server/src/modules/question/domain/Question.ts
@@ -1,0 +1,79 @@
+import QuestionType from '../enum/QuestionType';
+import Hashtag from './Hashtag';
+import Option from './Option';
+import QuestionImage from './QuestionImage';
+import {
+  Question as pQuestion,
+  QuestionImage as pQuestionImage,
+  Hashtag as pHashtag,
+  Option as pOption,
+} from '@prisma/client';
+
+class Question {
+  public questionId: bigint;
+  public question: string;
+  public questionType: QuestionType;
+  public userId: bigint;
+  public answer: string;
+  public commentary: string;
+  public images: QuestionImage[];
+  public hashtags: Hashtag[];
+  public options: Option[];
+  public createdAt: Date;
+  public updatedAt: Date;
+  constructor(
+    questionId: bigint,
+    question: string,
+    questionType: QuestionType,
+    userId: bigint,
+    answer: string,
+    commentary: string,
+    images: QuestionImage[] | undefined,
+    hashtags: Hashtag[] | undefined,
+    options: Option[] | undefined,
+    createdAt: Date,
+    updatedAt: Date,
+  ) {
+    this.questionId = questionId;
+    this.question = question;
+    this.questionType = questionType;
+    this.userId = userId;
+    this.answer = answer;
+    this.commentary = commentary;
+    this.images = images;
+    this.hashtags = hashtags;
+    this.options = options;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static of(record: pQuestion) {
+    return new Question(
+      record.question_id,
+      record.question,
+      QuestionType[record.question_type],
+      record.user_id,
+      record.answer,
+      record.commentary,
+      undefined,
+      undefined,
+      undefined,
+      record.created_at,
+      record.updated_at,
+    );
+  }
+
+  setImages(images: pQuestionImage[]) {
+    this.images = images.map((image) => QuestionImage.of(image));
+  }
+
+  setHashtags(hashtags: pHashtag[]) {
+    this.hashtags = hashtags.map((hashtag) => Hashtag.of(hashtag));
+  }
+
+  setOptions(options: pOption[]) {
+    this.options = options.map((option) => Option.of(option));
+  }
+}
+
+export default Question;

--- a/server/src/modules/question/domain/Question.ts
+++ b/server/src/modules/question/domain/Question.ts
@@ -10,7 +10,7 @@ import {
 } from '@prisma/client';
 
 class Question {
-  public questionId: bigint;
+  public questionId: bigint | undefined;
   public question: string;
   public questionType: QuestionType;
   public userId: bigint;
@@ -61,6 +61,10 @@ class Question {
       record.created_at,
       record.updated_at,
     );
+  }
+
+  setId(questionId: bigint) {
+    this.questionId = questionId;
   }
 
   setImages(images: pQuestionImage[]) {

--- a/server/src/modules/question/domain/QuestionImage.ts
+++ b/server/src/modules/question/domain/QuestionImage.ts
@@ -1,7 +1,7 @@
 import { QuestionImage as pQuestionImage } from '@prisma/client';
 
 class QuestionImage {
-  public questionImageId: bigint;
+  public questionImageId: bigint | undefined;
   public questionId: bigint;
   public path: string;
   constructor(questionImageId: bigint, questionId: bigint, path: string) {
@@ -12,6 +12,10 @@ class QuestionImage {
 
   static of(record: pQuestionImage) {
     return new QuestionImage(record.question_image_id, record.question_id, record.path);
+  }
+
+  setId(imageId: bigint) {
+    this.questionImageId = imageId;
   }
 }
 

--- a/server/src/modules/question/domain/QuestionImage.ts
+++ b/server/src/modules/question/domain/QuestionImage.ts
@@ -1,0 +1,18 @@
+import { QuestionImage as pQuestionImage } from '@prisma/client';
+
+class QuestionImage {
+  public questionImageId: bigint;
+  public questionId: bigint;
+  public path: string;
+  constructor(questionImageId: bigint, questionId: bigint, path: string) {
+    this.questionImageId = questionImageId;
+    this.questionId = questionId;
+    this.path = path;
+  }
+
+  static of(record: pQuestionImage) {
+    return new QuestionImage(record.question_image_id, record.question_id, record.path);
+  }
+}
+
+export default QuestionImage;

--- a/server/src/modules/question/enum/QuestionType.ts
+++ b/server/src/modules/question/enum/QuestionType.ts
@@ -1,0 +1,6 @@
+enum QuestionType {
+  MULTIPLE = 'MULTIPLE',
+  SUBJECTIVE = 'SUBJECTIVE',
+}
+
+export default QuestionType;

--- a/server/src/modules/user/enum/OauthType.ts
+++ b/server/src/modules/user/enum/OauthType.ts
@@ -1,4 +1,4 @@
-export enum OauthType {
+enum OauthType {
   GITHUB = 'GITHUB',
   NAVER = 'NAVER',
   KAKAO = 'KAKAO',


### PR DESCRIPTION
## 개요

- Question 도메인 도메인 클래스 및 레포지토리 생성, 조회 쿼리 구현



## 주요 작업사항

- Question 도메인에 필요한 도메인 클래스들을 구현했습니다.
  - Question 클래스
  - QuestionImage 클래스
  - Option 클래스
  - Hashtag 클래스
  - QuestionHashtag의 경우 별도의 domain 클래스가 필요해 보이지는 않아 배제했습니다.
- 필요한 enum 클래스를 구현했습니다.
  - QuestionType
- QuestionRepository 내에 생성 메소드를 구현했습니다.
  - 문제 생성 쿼리
  - 문제 이미지 생성 쿼리
  - 해쉬태그 생성 쿼리
  - 문제-해쉬태그 생성 쿼리
  - 문제 선택지 생성 쿼리
- QuestionRepository 내에 조회 메소드를 구현했습니다.
  - 특정 유저가 제작한 문제 다건 조회 쿼리
  - 특정 유저가 제작한 문제와 이미지, 해쉬태그, 선택지 상세 정보를 함께 조회해오는 다건 조회 쿼리
  - hashtag를 이용한 문제 다건 조회 쿼리
  - hashtag를 이용해 문제와 이미지, 해쉬태그, 선택지 상세 정보를 함께 조회해오는 다건 조회 쿼리


## 팀원분들께..

- 문제부분이 확실히 연관관계가 많다보니 복잡하네요. 사실 문제집이나 시험도 이정도 될 것 같은데 예상대로 난이도는 높습니다. 그래도 못할정도는 아니네요.
- QuestionRepository 내에도 주석으로 적어놨지만 두 가지 토의 거리가 존재합니다.
  - 객관식에 한해서만 Option table과 Join하게 할 수는 없을까?
  - 문제집에 공개범위가 있을게 아니라 문제에 공개범위가 있어야 하나? 왜냐면 한개의 문제가 여러 문제집과 연관되어 있을 수 있는데 그렇다면 어떤 문제집을 기준으로...? 첫 문제집..? 그렇다면 차라리 공개여부 column을 문제에도 만들어 두는건 어떨까?
