### PR TITLE
[refecor] common dropdown 방식 변경

### DIFF
--- a/client/src/components/common/Dropdown.tsx
+++ b/client/src/components/common/Dropdown.tsx
@@ -1,36 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-const DropdownStyled = styled.div`
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-
-  width: 150px;
-
-  border: 1px solid #afb8c1;
-  border-radius: 8px;
-
-  > * {
-    border: none;
-    background: none;
-    padding: 8px 8px 8px 16px;
-
-    font-size: 14px;
-    text-align: left;
-
-    :hover {
-      opacity: 0.7;
-      background: #d0d7de;
-    }
-  }
-`;
-
 interface DropdownProps {
-  children: JSX.Element[];
+  text: string;
+  handleClick: () => void;
 }
-const Dropdown = ({ children }: DropdownProps) => {
-  return <DropdownStyled>{children.map((x, i) => x)}</DropdownStyled>;
+const Dropdown = ({ text, handleClick }: DropdownProps) => {
+  return <input type="button" value={text} onClick={handleClick} />;
 };
 
 export default Dropdown;

--- a/client/src/components/common/DropdownContainer.tsx
+++ b/client/src/components/common/DropdownContainer.tsx
@@ -1,44 +1,61 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { HiArrowCircleDown } from 'react-icons/hi';
+import { MdArrowDropDown } from 'react-icons/md';
+import { RiArrowDropDownLine } from 'react-icons/ri';
 import dropdownArrow from '../../images/dropdown-arrow.svg';
-import Dropdown from './Dropdown';
+import { colors } from '../../styles/theme';
 
 const DropButton = styled.div``;
-
 const DropdownTitleContainer = styled.summary`
   display: flex;
   flex-direction: row;
   gap: 4px;
-
   ::marker {
     display: none;
     content: '';
   }
 `;
-
 const DropdownTitle = styled.div``;
-
 const DropdownArrow = styled.img`
   width: 14px;
 `;
-
+const DropdownStyled = styled.div`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  width: 150px;
+  border: 1px solid #afb8c1;
+  border-radius: 8px;
+  > * {
+    border: none;
+    background: ${colors.white};
+    padding: 8px 8px 8px 16px;
+    font-size: 14px;
+    text-align: left;
+    :hover {
+      background: #d0d7de;
+    }
+  }
+`;
 type DropdownContainerProps = {
   title: JSX.Element;
+  // eslint-disable-next-line react/require-default-props
+  arrowType?: string;
+  // eslint-disable-next-line react/require-default-props
+  iconSize?: number;
   children: JSX.Element[];
 };
 
-// title을 어떻게 받는게 효율적일까요..? 일단 img도 오고 string도 올수 있겠다 생각해서 element로 처리해봤습니다
-const DropdownContainer = ({ title, children }: DropdownContainerProps) => {
+const DropdownContainer = ({ title, arrowType = '2', iconSize = 20, children }: DropdownContainerProps) => {
   const [isToggled, setIsToggled] = useState<boolean>(false);
   const detailsRef: any = useRef(null);
-
   useEffect(() => {
     function handleClickOutside(e: any) {
       if (detailsRef.current && !detailsRef.current.contains(e.target)) {
         setIsToggled(false);
       }
     }
-
     // Bind the event listener
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
@@ -46,7 +63,6 @@ const DropdownContainer = ({ title, children }: DropdownContainerProps) => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, []);
-
   return (
     <DropButton
       ref={detailsRef}
@@ -56,10 +72,11 @@ const DropdownContainer = ({ title, children }: DropdownContainerProps) => {
     >
       <DropdownTitleContainer>
         <DropdownTitle>{title}</DropdownTitle>
-        <DropdownArrow src={dropdownArrow} alt="" />
+        {arrowType === '1' && <HiArrowCircleDown size={iconSize} />}
+        {arrowType === '2' && <MdArrowDropDown size={iconSize} />}
+        {arrowType === '3' && <RiArrowDropDownLine size={iconSize} />}
       </DropdownTitleContainer>
-
-      {isToggled ? <Dropdown>{children}</Dropdown> : null}
+      {isToggled && <DropdownStyled> {children}</DropdownStyled>}
     </DropButton>
   );
 };


### PR DESCRIPTION
## 개요

- dropdown 방식 변경
- dropdown icon 선택기능 추가



## 주요 작업사항

- 아래와 같은 코드 방식으로 common dropdown 사용 가능.
- arrowType : dropdown icon의 타입 선택 (default = "2")
  - "0" : icon 사용 안함.
  - "1" : [HiArrowCircleDown](https://react-icons.github.io/react-icons/search?q=hiarrowcircledown)
  - "2" : [MdArrowDropDown(4번째꺼)](https://react-icons.github.io/react-icons/search?q=mdarrowdropdown)
  - "3" : [RiArrowDropDownLine](https://react-icons.github.io/react-icons/search?q=riarrowdropdownline)
- iconSize : icon의 크기 조절 (default = 20)
```javascript
<DropdownContainer title={<div>로그인</div>} arrowType="0" iconSize={20}>
        <Dropdown
          text="1"
          handleClick={() => {
            alert(1);
          }}
        />
        <Dropdown
          text="2"
          handleClick={() => {
            alert(2);
          }}
        />
</DropdownContainer>
```


## 팀원분들께..

- 
