### PR TITLE
[FIX] frontend cicd 동작 성공 및 브랜치 develop으로 변경

### DIFF
--- a/.github/workflows/front_dev.yml
+++ b/.github/workflows/front_dev.yml
@@ -18,3 +18,4 @@ jobs:
             cd web07-zokboo.com
             git pull
             npm install
+            pm2 restart front-dev-server

--- a/.github/workflows/front_dev.yml
+++ b/.github/workflows/front_dev.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [fix/frontend_cicd]
+    branches: [develop]
 
 jobs:
   build:

--- a/.github/workflows/front_dev.yml
+++ b/.github/workflows/front_dev.yml
@@ -1,16 +1,17 @@
 on:
   push:
-    branches: [develop]
+    branches: [fix/frontend_cicd]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: dev_front
     steps:
       - name: deploy
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.REMOTE_IP }}
           username: ${{ secrets.REMOTE_SSH_ID }}
-          key: ${{ secrets.REMOTE_SSH_KEY }}
+          password: ${{ secrets.REMOTE_PASSWORD }}
           port: ${{ secrets.REMOTE_SSH_PORT }}
           script: ${{ secrets.REMOTE_SCRIPTS }}

--- a/.github/workflows/front_dev.yml
+++ b/.github/workflows/front_dev.yml
@@ -8,10 +8,13 @@ jobs:
     environment: dev_front
     steps:
       - name: deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v0.1.5
         with:
           host: ${{ secrets.REMOTE_IP }}
           username: ${{ secrets.REMOTE_SSH_ID }}
           password: ${{ secrets.REMOTE_PASSWORD }}
           port: ${{ secrets.REMOTE_SSH_PORT }}
-          script: ${{ secrets.REMOTE_SCRIPTS }}
+          script: |
+            cd web07-zokboo.com
+            git pull
+            npm install


### PR DESCRIPTION
## 개요

- [fix/frontend_cicd 브랜치에서 action 동작 성공](https://github.com/boostcampwm-2022/web07-zokboo.com/actions/runs/3570512079)



## 주요 작업사항

- key => password 변경
- script 환경변수 => 파일로 가져옴
- 동작 완료되어 브랜치명 develop으로 변경


## 팀원분들께..

- key 오류가 맞았습니다 ... 
