### PR TITLE
[FEAT] Search Workbook save

### DIFF
--- a/client/src/api/search.ts
+++ b/client/src/api/search.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { QueryFunctionContext } from 'react-query';
-import { DEV_SERVER_URL, SERVER_URL } from '../utils/constants';
+import { SERVER_URL } from '../utils/constants';
 
 export const getSearchData = async ({ queryKey }: QueryFunctionContext) => {
   const [_key, searchWord] = queryKey;
   const { data } = await axios
-    .get(`${DEV_SERVER_URL}/workbooks/search`, { params: { title: searchWord, content: '213123213' } })
+    .get(`${SERVER_URL}/workbooks/search`, { params: { title: searchWord, content: '213123213' } })
     .catch((err) => err.response);
 
   return data;

--- a/client/src/api/workbook.ts
+++ b/client/src/api/workbook.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { PatchSolveWorkbookQuestionProps, PostCreateWorkbookBody } from '../types/workbook';
+import { PatchSolveWorkbookQuestionProps, PostCreateWorkbookBody, PostWorkbookSave } from '../types/workbook';
 import { SERVER_URL } from '../utils/constants';
 
 export const getWorkbookList = async (params: number) => {
@@ -24,6 +24,14 @@ export const solveWorkbookQuestion = async (props: PatchSolveWorkbookQuestionPro
   const { params, body } = props;
   const { workbookId, workbookQuestionId } = params;
   const { data } = await axios.patch(`${SERVER_URL}/workbooks/${workbookId}/${workbookQuestionId}`, body, {
+    withCredentials: true,
+  });
+
+  return data;
+};
+
+export const saveWorkbook = async (body: PostWorkbookSave) => {
+  const { data } = await axios.post(`${SERVER_URL}/workbooks/save`, body, {
     withCredentials: true,
   });
 

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -33,7 +33,7 @@ const Header = () => {
   };
 
   const handleSearchToggle = () => {
-    if (isToggle) handleSearchWorkbook();
+    if (isToggle && input) handleSearchWorkbook();
     else handleToggle();
   };
 
@@ -46,7 +46,13 @@ const Header = () => {
 
         <ButtonInner>
           <SearchContainer isToggle={isToggle}>
-            <SearchInput placeholder="검색어를 입력하세요." onChange={(e) => setInput(e.target.value)} />
+            <SearchInput
+              placeholder="검색어를 입력하세요."
+              onKeyUp={(e) => {
+                if (e.key === 'Enter') handleSearchWorkbook();
+              }}
+              onChange={(e) => setInput(e.target.value)}
+            />
             <SearchButton onClick={handleSearchToggle}>
               <BiSearchAlt2 size={30} />
             </SearchButton>

--- a/client/src/types/workbook.ts
+++ b/client/src/types/workbook.ts
@@ -47,3 +47,7 @@ export interface GetWorkbookListByTitleResponse {
   description: string;
   questions: GetQuestionResponse[];
 }
+
+export interface PostWorkbookSave {
+  workbookId: number;
+}


### PR DESCRIPTION
## 개요

- 문제집 저장 기능 추가



## 주요 작업사항

- 문제집 저장 api 쿼리만 일단 작성 
  -> 어떤 방식으로 할 지 아직 안나와서 post에 url은 " /workbooks/save " body에는 workbookId를 넣어서 넘겼습니다. 
      이건 확정 되면 결과에 따라 수정 될 수 있음


## 팀원분들께..

- 현재 검색 결과 페이지를 사용할 수 없다고 판단하여서 추가적인 작업은 하지 않았습니다. 
![image](https://user-images.githubusercontent.com/52366178/205854686-490d7c46-df1a-42d9-a353-d8feaa475e62.png)
저장 버튼의 부재, 썸네일 부분의 용도, 레이아웃이 안맞음 등의 문제 확인으로 수정될 가능성이 있다고 판단해서 
아에 건들이지 않았습니다. 

- @caseBread 
![image](https://user-images.githubusercontent.com/52366178/205854888-254f05d0-374e-45e3-9d26-8709df01df97.png)
검색 API에 어떻게 남아있는지 모르겠는데 과거의 잔재가 남아있었습니다. 
커밋할 때 실행 후 문제가 없는지 확인 한번 부탁드립니다. 
( PR 꼬이면 생각보다 충돌 잡는게 귀찮아짐 )
일단 해당 부분은 제가 수정해서 이번 PR에 함께 올렸습니다. 

- 사실상 이번 PR은 기능 전체 완료가 아니기 때문에 이슈와 합치진 않겠습니다. 
