### PR TITLE
[FEAT] 로그아웃 API 작성

### DIFF
--- a/server/src/modules/auth/AuthController.ts
+++ b/server/src/modules/auth/AuthController.ts
@@ -10,7 +10,7 @@ import OauthType from '../user/enum/OauthType';
 import { User } from 'src/decorators/UserDecorator';
 import { Response } from 'express';
 import SignupResponse from '../user/dto/response/SignupResponse';
-import { ApiExcludeEndpoint, ApiExtraModels, ApiOkResponse } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiExtraModels, ApiNoContentResponse, ApiOkResponse } from '@nestjs/swagger';
 import SigninResponse from '../user/dto/response/SigninResponse';
 import { MailService } from '../common/MailService';
 import { ApiSingleResponse } from 'src/decorators/ApiResponseDecorator';
@@ -44,6 +44,7 @@ export class AuthController {
   }
 
   @Get('logout')
+  @ApiNoContentResponse({ description: '로그아웃 완료' })
   async logout(@Res() res: Response) {
     res.clearCookie('accessToken');
 

--- a/server/src/modules/auth/AuthController.ts
+++ b/server/src/modules/auth/AuthController.ts
@@ -43,6 +43,13 @@ export class AuthController {
     return new ApiResponse('verify status', verifyResult);
   }
 
+  @Get('logout')
+  async logout(@Res() res: Response) {
+    res.clearCookie('accessToken');
+
+    res.status(204).send();
+  }
+
   @Post('signin')
   @ApiSingleResponse(200, SigninResponse, '로그인 완료')
   async signin(@Body() request: SigninRequest, @Res() response: Response) {


### PR DESCRIPTION

## 개요

- 로그아웃 API 작성



## 주요 작업사항

- GET /auth/logout


## 팀원분들께..

워딩을 고민했는데, signin, signup, signout은 원래 두 단어로 되어 있는 형태이고, 실제 사용시에도 단어를 붙이지 않고 사용합니다. (Sign in, Sign up, Sign out 등의 형식으로) login, logout의 경우, 붙여서 사용하는 형태가 더 많이 사용되고 있어서 상황에 맞게 두 워딩을 사용한다고 합니다. (Sign in, Sign up의 혼동을 피하기 위해 Sign up에 Register를 사용하는 경우도 있음) signout 자체가 한 단어가 아니어서 IDE에서 문법 경고를 띄워주기도 하고, 개인적으로 sign out 보다 logout이 더 이해하기 쉬운 단어라고 생각해서 API path를 logout으로 작성했습니다. 이 부분에 대해 코멘트를 남기고 싶다면 자유롭게 남겨주세요!

ps. 실질적인 코드 리뷰는 없습니다. (7 lines with clearing cookie)