### PR TITLE
[FEAT] 공유받은 문제집 조회 API

### DIFF
--- a/server/src/modules/workbook/WorkbookController.ts
+++ b/server/src/modules/workbook/WorkbookController.ts
@@ -54,6 +54,15 @@ export class WorkbookController {
     return new ApiResponse('문제집 검색 성공', response);
   }
 
+  @Get('saved')
+  @UseGuards(JwtAuthGuard)
+  @ApiMultiResponse(200, WorkbookSimpleResponse, '공유받은 문제집 조회 성공')
+  async getSavedWorkbooks(@User('id') userId: string) {
+    const response = await this.workbookService.getSavedWorkbooks(Number(userId));
+
+    return new ApiResponse('공유받은 문제집 조회 성공', response);
+  }
+
   @Get(':workbookId')
   @ApiSingleResponse(200, WorkbookDetailResponse, '문제집 조회 성공')
   async showWorkbook(@Param('workbookId', ParseIntPipe) workbookId: number) {

--- a/server/src/modules/workbook/WorkbookRepository.ts
+++ b/server/src/modules/workbook/WorkbookRepository.ts
@@ -175,6 +175,34 @@ export class WorkbookRepository {
     return response;
   }
 
+  async findSavedWorkbooks(userId: number) {
+    const workbooks = await this.prismaInstance.workbook.findMany({
+      where: {
+        original_id: {
+          not: null,
+        },
+        user_id: userId,
+      },
+      include: {
+        WorkbookQuestion: {
+          include: {
+            Question: true,
+          },
+        },
+      },
+    });
+
+    return workbooks.map((workbook) => {
+      const questions = workbook.WorkbookQuestion.map((wq) => {
+        const question = Question.of(wq.Question);
+        return WorkbookQuestion.of(wq, question);
+      });
+      const response = Workbook.of(workbook);
+      response.setQuestions(questions);
+      return response;
+    });
+  }
+
   async findWorkbookQuestion(workbookQuestionId: number, tx?: Prisma.TransactionClient) {
     const prisma = tx ? tx : this.prismaInstance;
     const workbookQuestion = await prisma.workbookQuestion.findUnique({

--- a/server/src/modules/workbook/WorkbookService.ts
+++ b/server/src/modules/workbook/WorkbookService.ts
@@ -65,6 +65,12 @@ export class WorkbookService {
     return result;
   }
 
+  async getSavedWorkbooks(userId: number) {
+    const result = await this.workbookRepository.findSavedWorkbooks(userId);
+
+    return result.map((workbook) => new WorkbookSimpleResponse(workbook));
+  }
+
   async solveWorkbookQuestion(
     workbookId: number,
     workbookQuestionId: number,


### PR DESCRIPTION

## 개요

- 공유받은 문제집 목록 조회 API 추가

## 주요 작업사항

- 개요와 같이, 공유받은 문제집 목록 조회 API 추가


## 팀원분들께..

**Transaction을 사용하지 않음**
- 문제집을 공유한 순간 원본 문제집의 내용이 복사되어 original_id를 가지고 저장되고 사용자가 문제 풀이, 시험지 만들기 등을 진행할 수 있습니다. (원본과는 완전히 다른 새로운 row가 DB에 쌓임)
- 이렇게 공유받은 문제집은 타인이 변경할 수 없으며, 정상적인 서비스 흐름 안에서 사용자는 문제집을 조회하는 순간에 동시에 해당 문제집 변경을 진행할 수 없습니다.
- 그렇기 때문에 조회시에 해당 데이터에 대한 일관성을 해치지 않아서 transaction을 적용할 필요가 없는 API라고 판단했고, transaction을 사용하지 않았습니다.
- 이 상황에 대한 다른 의견이 있으면 편하게 코멘트 달아주세요!
