### PR TITLE
[FEAT] 시험지 상태 별 리스트 / 상세 조회 API 구현

### DIFF
--- a/server/src/modules/testPaper/TestPaperController.ts
+++ b/server/src/modules/testPaper/TestPaperController.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Put, UseGuards } from '@nestjs/common';
-import { ApiExtraModels } from '@nestjs/swagger';
-import { ApiSingleResponse } from 'src/decorators/ApiResponseDecorator';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { ApiExtraModels, ApiQuery } from '@nestjs/swagger';
+import { ApiMultiResponse, ApiSingleResponse } from 'src/decorators/ApiResponseDecorator';
 import { User } from 'src/decorators/UserDecorator';
 import { JwtAuthGuard } from '../auth/guard/jwtAuthGuard';
 import ApiResponse from '../common/response/ApiResponse';
@@ -15,6 +15,8 @@ import GradeTestPaperQuestionRequest from './dto/request/GradeTestPaperQuestionR
 import TestPaperQuestionDetailResponse from './dto/response/TestPaperQuestionDetailResponse';
 import MarkTestPaperRequest from './dto/request/MarkTestPaperRequest';
 import MarkTestPaperQuestionRequest from './dto/request/MarkTestPaperQuestionRequest';
+import TestPaperSimpleResponse from './dto/response/TestPaperSimpleResponse';
+import TestPaperState from './enum/TestPaperState';
 
 @Controller('testpaper')
 @ApiExtraModels(
@@ -25,6 +27,7 @@ import MarkTestPaperQuestionRequest from './dto/request/MarkTestPaperQuestionReq
   TestPaperGradedResponse,
   GradeTestPaperQuestionRequest,
   MarkTestPaperQuestionRequest,
+  TestPaperSimpleResponse,
 )
 export class TestPaperController {
   constructor(private readonly testPaperService: TestPaperService) {}
@@ -35,6 +38,22 @@ export class TestPaperController {
   async createTestPaper(@User('id') userId: string, @Body() request: CreateTestPaperRequest) {
     const response = await this.testPaperService.createTestPaper(request, Number(userId));
     return new ApiResponse('시험지 생성 성공', response);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiQuery({
+    name: 'state',
+    enum: TestPaperState,
+    required: false,
+  })
+  @ApiMultiResponse(200, TestPaperSimpleResponse, '시험지 리스트 조회 성공')
+  async showTestPapers(@User('id') userId: string, @Query('state') state?: TestPaperState) {
+    const response = await this.testPaperService.getTestPapersOfUserByState(
+      Number(userId),
+      state ? state : TestPaperState.SOLVING,
+    );
+    return new ApiResponse('시험지 리스트 조회 성공', response);
   }
 
   @Get(':testPaperId')

--- a/server/src/modules/testPaper/TestPaperService.ts
+++ b/server/src/modules/testPaper/TestPaperService.ts
@@ -13,6 +13,8 @@ import TestPaperGradedResponse from './dto/response/TestPaperGradedResponse';
 import TestPaperDetailResponse from './dto/response/TestPaperDetailResponse';
 import TestPaperState from './enum/TestPaperState';
 import { TestPaperRepository } from './TestPaperRepository';
+import ReviewNoteResponse from './dto/response/ReviewNoteResponse';
+import TestPaperSimpleResponse from './dto/response/TestPaperSimpleResponse';
 
 @Injectable()
 export class TestPaperService {
@@ -41,9 +43,24 @@ export class TestPaperService {
     return result;
   }
 
+  async getTestPapersOfUserByState(userId: number, state: TestPaperState) {
+    const testPapers = await this.testPaperRepository.findTestPapersOfUser(userId, state);
+    return testPapers.map((tp) => new TestPaperSimpleResponse(tp));
+  }
+
   async getTestPaperWithDetails(userId: number, testPaperId: number) {
     const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
     return new TestPaperDetailResponse(testPaper);
+  }
+
+  async getGradedTestPaper(userId: number, testPaperId: number) {
+    const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
+    return new TestPaperGradedResponse(testPaper);
+  }
+
+  async getReviewNote(userId: number, testPaperId: number) {
+    const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
+    return new ReviewNoteResponse(testPaper);
   }
 
   async gradeMultipleTypeQuestionsOfTestPaper(userId: number, testPaperId: number, request: GradeTestPaperRequest) {

--- a/server/src/modules/testPaper/TestPaperService.ts
+++ b/server/src/modules/testPaper/TestPaperService.ts
@@ -50,17 +50,21 @@ export class TestPaperService {
 
   async getTestPaperWithDetails(userId: number, testPaperId: number) {
     const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
-    return new TestPaperDetailResponse(testPaper);
-  }
-
-  async getGradedTestPaper(userId: number, testPaperId: number) {
-    const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
-    return new TestPaperGradedResponse(testPaper);
-  }
-
-  async getReviewNote(userId: number, testPaperId: number) {
-    const testPaper = await this.getTestPaperByIdWithAuthorization(userId, testPaperId);
-    return new ReviewNoteResponse(testPaper);
+    let result: TestPaperDetailResponse | TestPaperGradedResponse | ReviewNoteResponse;
+    switch (testPaper.state) {
+      case TestPaperState.SOLVING:
+        result = new TestPaperDetailResponse(testPaper);
+        break;
+      case TestPaperState.GRADING:
+        result = new TestPaperGradedResponse(testPaper);
+        break;
+      case TestPaperState.COMPLETE:
+        result = new ReviewNoteResponse(testPaper);
+        break;
+      default:
+        break;
+    }
+    return result;
   }
 
   async gradeMultipleTypeQuestionsOfTestPaper(userId: number, testPaperId: number, request: GradeTestPaperRequest) {

--- a/server/src/modules/testPaper/domain/TestPaperQuestion.ts
+++ b/server/src/modules/testPaper/domain/TestPaperQuestion.ts
@@ -49,7 +49,8 @@ class TestPaperQuestion {
 
   solve(writtenAnswer: string | undefined) {
     if (writtenAnswer === undefined) {
-      throw new BadRequestException('풀리지 않은 문제가 있습니다.');
+      this.writtenAnswer = '';
+      return;
     }
     this.writtenAnswer = writtenAnswer;
   }
@@ -68,9 +69,6 @@ class TestPaperQuestion {
   }
 
   markSubjectiveTypeQuestion(result: boolean | undefined) {
-    if (result === undefined) {
-      throw new BadRequestException('채점되지 않은 문제가 있습니다.');
-    }
     if (result) {
       this.state = TestPaperQuestionState.CORRECT;
       return true;

--- a/server/src/modules/testPaper/dto/response/ReviewNoteQuestionResponse.ts
+++ b/server/src/modules/testPaper/dto/response/ReviewNoteQuestionResponse.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import TestPaperQuestion from '../../domain/TestPaperQuestion';
+import TestPaperQuestionDetailResponse from './TestPaperQuestionDetailResponse';
+
+class ReviewNoteQuestionResponse extends TestPaperQuestionDetailResponse {
+  @ApiProperty()
+  public review: string;
+
+  constructor(testPaperQuestion: TestPaperQuestion) {
+    super(testPaperQuestion);
+    this.review = testPaperQuestion.review;
+  }
+}
+
+export default ReviewNoteQuestionResponse;

--- a/server/src/modules/testPaper/dto/response/ReviewNoteResponse.ts
+++ b/server/src/modules/testPaper/dto/response/ReviewNoteResponse.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import TestPaper from '../../domain/TestPaper';
+import ReviewNoteQuestionResponse from './ReviewNoteQuestionResponse';
+import TestPaperSimpleResponse from './TestPaperSimpleResponse';
+
+class ReviewNoteResponse extends TestPaperSimpleResponse {
+  @ApiProperty({
+    type: 'array',
+    items: {
+      $ref: getSchemaPath(ReviewNoteQuestionResponse),
+    },
+  })
+  public questions: ReviewNoteQuestionResponse[];
+
+  constructor(testPaper: TestPaper) {
+    super(testPaper);
+    this.questions = testPaper.questions.map((q) => new ReviewNoteQuestionResponse(q));
+  }
+}
+
+export default ReviewNoteResponse;

--- a/server/src/modules/testPaper/dto/response/TestPaperQuestionDetailResponse.ts
+++ b/server/src/modules/testPaper/dto/response/TestPaperQuestionDetailResponse.ts
@@ -10,9 +10,17 @@ class TestPaperQuestionDetailResponse extends TestPaperQuestionSimpleResponse {
   })
   public state: TestPaperQuestionState;
 
+  @ApiProperty()
+  public answer: string;
+
+  @ApiProperty()
+  public commentary: string;
+
   constructor(testPaperQuestion: TestPaperQuestion) {
     super(testPaperQuestion);
     this.state = testPaperQuestion.state;
+    this.answer = testPaperQuestion.question.answer;
+    this.commentary = testPaperQuestion.question.commentary;
   }
 }
 


### PR DESCRIPTION
## 개요

- 시험지 상태 별 리스트 / 상세 조회 API 구현



## 주요 작업사항

- 리스트 조회의 경우 query parameter로 state를 함께 보내 특정 상태의 시험지들을 불러올 수 있습니다.
  - default는 SOLVING입니다.
- 상세 조회의 경우 하나의 API로 통일했으며 각 시험지의 state별로 넘어가는 정보가 상이합니다.
  - SOLVING : 시험지, 시험 정보, 문제 기본 정보 및 작성 답안
  - GRADING : 위의 정보 + 객관식 문제 정답 여부 + 각 문제의 정답과 해설
  - COMPLETE : 위의 정보 + 각 문제 별 review(오답노트)


## 팀원분들께..

- 
