### PR TITLE
[FEAT] 오답노트 작성 API 구현

### DIFF
--- a/server/src/modules/testPaper/TestPaperController.ts
+++ b/server/src/modules/testPaper/TestPaperController.ts
@@ -17,6 +17,8 @@ import MarkTestPaperRequest from './dto/request/MarkTestPaperRequest';
 import MarkTestPaperQuestionRequest from './dto/request/MarkTestPaperQuestionRequest';
 import TestPaperSimpleResponse from './dto/response/TestPaperSimpleResponse';
 import TestPaperState from './enum/TestPaperState';
+import ReviewQuestionResponse from './dto/response/ReviewQuestionResponse';
+import ReviewQuestionRequest from './dto/request/ReviewQuestionRequest';
 
 @Controller('testpapers')
 @ApiExtraModels(
@@ -94,5 +96,17 @@ export class TestPaperController {
       request,
     );
     return new ApiResponse('시험지 주관식 문제 채점 성공', response);
+  }
+
+  @Patch(':testPaperQuestionId')
+  @UseGuards(JwtAuthGuard)
+  @ApiSingleResponse(200, ReviewQuestionResponse, '시험지 문제 오답노트 작성 성공')
+  async reviewTestPaperQuestion(
+    @User('id') userId: string,
+    @Param('testPaperQuestionId', ParseIntPipe) testPaperQuestionId: number,
+    @Body() request: ReviewQuestionRequest,
+  ) {
+    const response = await this.testPaperService.reviewTestPaperQuestion(Number(userId), testPaperQuestionId, request);
+    return new ApiResponse('시험지 문제 오답노트 작성 성공', response);
   }
 }

--- a/server/src/modules/testPaper/TestPaperRepository.ts
+++ b/server/src/modules/testPaper/TestPaperRepository.ts
@@ -205,8 +205,30 @@ export class TestPaperRepository {
           return WorkbookTest.of(wt, workbook);
         }),
       );
-      const testPaper = TestPaper.of(tp, test);
-      return testPaper;
+      return TestPaper.of(tp, test);
     });
+  }
+
+  async findTestPaperQuestion(testPaperQuestionId: number, tx?: Prisma.TransactionClient) {
+    const prisma = tx ? tx : this.prismaInstance;
+    const testPaperQuestion = await prisma.testPaperQuestion.findUnique({
+      where: {
+        test_paper_question_id: testPaperQuestionId,
+      },
+      include: {
+        TestPaper: {
+          include: {
+            Test: true,
+          },
+        },
+        Question: true,
+      },
+    });
+    if (!testPaperQuestion) {
+      return null;
+    }
+    const result = TestPaperQuestion.of(testPaperQuestion, Question.of(testPaperQuestion.Question));
+    result.setTestPaper(TestPaper.of(testPaperQuestion.TestPaper, Test.of(testPaperQuestion.TestPaper.Test)));
+    return result;
   }
 }

--- a/server/src/modules/testPaper/domain/TestPaperQuestion.ts
+++ b/server/src/modules/testPaper/domain/TestPaperQuestion.ts
@@ -2,7 +2,7 @@ import Question from 'src/modules/question/domain/Question';
 import { TestPaperQuestion as pTestPaperQuestion } from '@prisma/client';
 import TestPaperQuestionState from '../enum/TestPaperQuestionState';
 import QuestionType from 'src/modules/question/enum/QuestionType';
-import { BadRequestException } from '@nestjs/common';
+import TestPaper from './TestPaper';
 
 class TestPaperQuestion {
   public testPaperQuestionId: bigint | undefined;
@@ -11,6 +11,7 @@ class TestPaperQuestion {
   public writtenAnswer: string;
   public review: string;
   public question: Question;
+  public testPaper: TestPaper;
 
   constructor(
     testPaperQuestionId: bigint | undefined,
@@ -19,6 +20,7 @@ class TestPaperQuestion {
     writtenAnswer: string,
     review: string,
     question: Question,
+    testPaper: TestPaper,
   ) {
     this.testPaperQuestionId = testPaperQuestionId;
     this.testPaperId = testPaperId;
@@ -26,6 +28,7 @@ class TestPaperQuestion {
     this.writtenAnswer = writtenAnswer;
     this.review = review;
     this.question = question;
+    this.testPaper = testPaper;
   }
 
   static of(testPaperQuestion: pTestPaperQuestion, question: Question) {
@@ -36,15 +39,20 @@ class TestPaperQuestion {
       testPaperQuestion.written_answer,
       testPaperQuestion.review,
       question,
+      undefined,
     );
   }
 
   static new(question: Question) {
-    return new TestPaperQuestion(undefined, undefined, TestPaperQuestionState.UNMARKED, '', '', question);
+    return new TestPaperQuestion(undefined, undefined, TestPaperQuestionState.UNMARKED, '', '', question, undefined);
   }
 
   setId(testPaperQuestionId: bigint) {
     this.testPaperQuestionId = testPaperQuestionId;
+  }
+
+  setTestPaper(testPaper: TestPaper) {
+    this.testPaper = testPaper;
   }
 
   solve(writtenAnswer: string | undefined) {
@@ -75,6 +83,10 @@ class TestPaperQuestion {
     }
     this.state = TestPaperQuestionState.WRONG;
     return false;
+  }
+
+  reviewQuestion(content: string) {
+    this.review = content;
   }
 }
 

--- a/server/src/modules/testPaper/dto/request/ReviewQuestionRequest.ts
+++ b/server/src/modules/testPaper/dto/request/ReviewQuestionRequest.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+class ReviewQuestionRequest {
+  @ApiProperty()
+  @IsString()
+  public review: string;
+}
+
+export default ReviewQuestionRequest;

--- a/server/src/modules/testPaper/dto/response/ReviewQuestionResponse.ts
+++ b/server/src/modules/testPaper/dto/response/ReviewQuestionResponse.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import TestPaperQuestion from '../../domain/TestPaperQuestion';
+
+export default class ReviewQuestionResponse {
+  @ApiProperty()
+  public testPaperQuestionId: number;
+
+  constructor(testPaperQuestion: TestPaperQuestion) {
+    this.testPaperQuestionId = Number(testPaperQuestion.testPaperQuestionId);
+  }
+}

--- a/server/src/modules/workbook/WorkbookController.ts
+++ b/server/src/modules/workbook/WorkbookController.ts
@@ -14,6 +14,7 @@ import WorkbookStateResponse from './dto/response/WorkbookStateResponse';
 import { WorkbookService } from './WorkbookService';
 import WorkbookQuestionSimpleResponse from './dto/response/WorkbookQuestionSimpleResponse';
 import WorkbookQuestionDetailResponse from './dto/response/WorkbookQuestionDetailResponse';
+import WorkbookSearchResponse from './dto/response/WorkbookSearchResponse';
 
 @Controller('workbooks')
 @ApiExtraModels(
@@ -25,6 +26,7 @@ import WorkbookQuestionDetailResponse from './dto/response/WorkbookQuestionDetai
   WorkbookQuestionSimpleResponse,
   WorkbookQuestionDetailResponse,
   WorkbookStateResponse,
+  WorkbookSearchResponse,
 )
 export class WorkbookController {
   constructor(private readonly workbookService: WorkbookService) {}
@@ -48,7 +50,7 @@ export class WorkbookController {
     type: String,
     required: false,
   })
-  @ApiMultiResponse(200, WorkbookSimpleResponse, '문제집 조회 / 검색 성공')
+  @ApiMultiResponse(200, WorkbookSearchResponse, '문제집 조회 / 검색 성공')
   async searchWorkbooks(@Query('title') title?: string, @Query('content') content?: string) {
     const response = await this.workbookService.searchWorkbooks(title, content);
     return new ApiResponse('문제집 조회 / 검색 성공', response);

--- a/server/src/modules/workbook/WorkbookRepository.ts
+++ b/server/src/modules/workbook/WorkbookRepository.ts
@@ -6,6 +6,7 @@ import Option from '../question/domain/Option';
 import Question from '../question/domain/Question';
 import QuestionImage from '../question/domain/QuestionImage';
 import QuestionType from '../question/enum/QuestionType';
+import User from '../user/domain/User';
 import Workbook from './domain/Workbook';
 import WorkbookQuestion from './domain/WorkbookQuestion';
 
@@ -117,12 +118,14 @@ export class WorkbookRepository {
             Question: true,
           },
         },
+        User_UserToWorkbook_user_id: true,
       },
     });
     return workbooks.map((w) => {
       const questions = w.WorkbookQuestion.map((wq) => WorkbookQuestion.of(wq, Question.of(wq.Question)));
       const workbook = Workbook.of(w);
       workbook.setQuestions(questions);
+      workbook.setUser(User.of(w.User_UserToWorkbook_user_id));
       return workbook;
     });
   }

--- a/server/src/modules/workbook/WorkbookService.ts
+++ b/server/src/modules/workbook/WorkbookService.ts
@@ -8,6 +8,7 @@ import SolveWorkbookQuestionRequest from './dto/request/SolveWorkbookQuestionReq
 import CreateWorkbookResponse from './dto/response/CreateWorkbookResponse';
 import WorkbookDetailResponse from './dto/response/WorkbookDetailResponse';
 import WorkbookQuestionSimpleResponse from './dto/response/WorkbookQuestionSimpleResponse';
+import WorkbookSearchResponse from './dto/response/WorkbookSearchResponse';
 import WorkbookSimpleResponse from './dto/response/WorkbookSimpleResponse';
 import WorkbookStateResponse from './dto/response/WorkbookStateResponse';
 import { WorkbookRepository } from './WorkbookRepository';
@@ -34,7 +35,7 @@ export class WorkbookService {
 
   async searchWorkbooks(title: string, content: string) {
     const workbooks = await this.workbookRepository.searchWorkbooks(title, content);
-    return workbooks.map((w) => new WorkbookSimpleResponse(w));
+    return workbooks.map((w) => new WorkbookSearchResponse(w));
   }
 
   async searchWorkbooksByUser(title: string, content: string, userId: number) {

--- a/server/src/modules/workbook/domain/Workbook.ts
+++ b/server/src/modules/workbook/domain/Workbook.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { Workbook as pWorkbook } from '@prisma/client';
+import User from 'src/modules/user/domain/User';
 import WorkbookQuestion from './WorkbookQuestion';
 
 class Workbook {
@@ -12,6 +13,7 @@ class Workbook {
   public questions: WorkbookQuestion[] | undefined;
   public createdAt: Date;
   public updatedAt: Date;
+  public user: User;
 
   constructor(
     workbookId: bigint | undefined,
@@ -23,6 +25,7 @@ class Workbook {
     questions: WorkbookQuestion[] | undefined,
     createdAt: Date,
     updatedAt: Date,
+    user: User,
   ) {
     this.workbookId = workbookId;
     this.title = title;
@@ -33,6 +36,7 @@ class Workbook {
     this.questions = questions;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.user = user;
   }
 
   static of(record: pWorkbook) {
@@ -46,12 +50,24 @@ class Workbook {
       undefined,
       record.created_at,
       record.updated_at,
+      undefined,
     );
   }
 
   static new(title: string, description: string, isPublic: boolean, userId: number) {
     const now = new Date();
-    return new Workbook(undefined, title, description, isPublic, BigInt(userId), undefined, undefined, now, now);
+    return new Workbook(
+      undefined,
+      title,
+      description,
+      isPublic,
+      BigInt(userId),
+      undefined,
+      undefined,
+      now,
+      now,
+      undefined,
+    );
   }
 
   static duplicate(workbook: Workbook, userId: number) {
@@ -69,6 +85,7 @@ class Workbook {
       undefined,
       now,
       now,
+      undefined,
     );
   }
 
@@ -81,6 +98,10 @@ class Workbook {
       throw new BadRequestException('문제집에 포함될 수 있는 문제 수는 5개에서 50개 입니다.');
     }
     this.questions = questions;
+  }
+
+  setUser(user: User) {
+    this.user = user;
   }
 }
 

--- a/server/src/modules/workbook/dto/response/WorkbookSearchResponse.ts
+++ b/server/src/modules/workbook/dto/response/WorkbookSearchResponse.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import User from 'src/modules/user/domain/User';
+import SigninResponse from 'src/modules/user/dto/response/SigninResponse';
+import Workbook from '../../domain/Workbook';
+import WorkbookSimpleResponse from './WorkbookSimpleResponse';
+
+export default class WorkbookSearchResponse extends WorkbookSimpleResponse {
+  @ApiProperty()
+  public user: SigninResponse;
+
+  constructor(workbook: Workbook) {
+    super(workbook);
+    this.user = new SigninResponse(workbook.user);
+  }
+}


### PR DESCRIPTION
## 개요

- 오답노트 작성 API 구현



## 주요 작업사항

- 오답노트 작성 API를 구현했습니다.
- 이제 문제집 검색 시 유저 정보가 함께 반환됩니다.


## 팀원분들께..

- @caseBread 요청하신대로 문제집 검색 API 를 수정했습니다.
