### PR TITLE
[FIX] GET /questions 에 hashtag 추가

### DIFF
--- a/server/src/modules/question/dto/response/GetQuestionsResponse.ts
+++ b/server/src/modules/question/dto/response/GetQuestionsResponse.ts
@@ -34,8 +34,8 @@ export default class GetQuestionsResponse {
   // @ApiProperty()
   // public updatedAt: Date;
 
-  // @ApiProperty()
-  // public hashtags: string[];
+  @ApiProperty()
+  public hashtags: string[];
 
   // @ApiProperty()
   // public options: string[] | undefined;
@@ -53,7 +53,7 @@ export default class GetQuestionsResponse {
     // this.commentary = record.commentary;
     // this.createdAt = record.createdAt;
     // this.updatedAt = record.updatedAt;
-    // this.hashtags = record.hashtags.map((h) => h.name);
+    this.hashtags = record.hashtags.map((h) => h.name);
     // if (record.questionType === QuestionType.MULTIPLE) {
     //   this.options = record.options.map((o) => o.content);
     // }


### PR DESCRIPTION
## 개요

- 프론트에서 필요로 하는 해시태그를 응답에 추가했습니다.

## 주요 작업사항

- 프론트에서 hashtag 목록을 필요로 해서, 주석처리 되어있던 부분 활성화

## 팀원분들께..

- 
